### PR TITLE
Add uploadArchives task configuration

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -54,6 +54,15 @@ dependencies {
     deployerJars 'org.springframework.build:aws-maven:5.0.0.RELEASE'
 }
 
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            configuration = project.configurations.deployerJars
+            repository id: 'com.asakusafw.releases', url: 's3://asakusafw/maven/releases'
+            snapshotRepository id: 'com.asakusafw.snapshots', url: 's3://asakusafw/maven/snapshots'
+        }
+    }
+}
 
 task assembleTemplates {
     description 'assembles application project templates'


### PR DESCRIPTION
## Summary

This PR adds `uploadArchives` task configuration to `build.gradle` of distribution Gradle plugin.
## Background, Problem or Goal of the patch

This PR fixes to deploy Gradle plugin artifact to Maven repository.
## Design of the fix, or a new feature

N/A.
## Related Issue, Pull Request or Code
#1
## Wanted reviewer

N/A.
