### PR TITLE
Refer transitive dependency `asakusafw-lang` plug-in in tests.

### DIFF
--- a/gradle/src/test/groovy/com/asakusafw/distribution/gradle/plugins/AsakusaUpgradeTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/distribution/gradle/plugins/AsakusaUpgradeTest.groovy
@@ -23,6 +23,7 @@ import org.junit.rules.TestName
 
 import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
 import com.asakusafw.gradle.plugins.GradleTestkitHelper
+import com.asakusafw.lang.gradle.plugins.AsakusafwLangPlugin
 import com.asakusafw.m3bp.gradle.plugins.AsakusafwM3bpPlugin
 import com.asakusafw.spark.gradle.plugins.AsakusafwSparkPlugin
 import com.asakusafw.vanilla.gradle.plugins.AsakusafwVanillaPlugin
@@ -83,10 +84,12 @@ class AsakusaUpgradeTest {
     private void doUpgrade(String version) {
         Set<File> classpath = GradleTestkitHelper.toClasspath(
             AsakusafwBasePlugin,
+            AsakusafwLangPlugin,
             AsakusafwSparkPlugin,
             AsakusafwM3bpPlugin,
             AsakusafwVanillaPlugin,
             'META-INF/gradle-plugins/asakusafw-sdk.properties',
+            'META-INF/gradle-plugins/asakusafw-lang.properties',
             'META-INF/gradle-plugins/asakusafw-spark.properties',
             'META-INF/gradle-plugins/asakusafw-m3bp.properties',
             'META-INF/gradle-plugins/asakusafw-vanilla.properties')


### PR DESCRIPTION
## Summary

This PR fixes test cases broken by asakusafw/asakusafw-compiler#142.

## Background, Problem or Goal of the patch

Gradle plug-in `asakusa-lang-gradle`, which is Introduced in asakusafw/asakusafw-compiler#142, is a transitive dependency of Asakusa Distribution Gradle plug-in via `asakusafw-{spark, m3bp, ...}`. And then `AsakusaUpgradeTest` must refer such dependencies, or test will be failed by linkage error.

## Design of the fix, or a new feature

To add classes and resources into `GradleTestkitHelper.toClasspath()` adds their artifacts into class-path of running tests.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#142
