### PR TITLE
Refer `asakusa-mapreduce-gradle` artifact.

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -50,12 +50,30 @@ dependencies {
     compile group: 'com.asakusafw.spark', name: 'asakusa-spark-gradle', version: System.getProperty('spark', versions.spark)
     compile group: 'com.asakusafw.m3bp', name: 'asakusa-m3bp-gradle', version: System.getProperty('m3bp', versions.m3bp)
     compile group: 'com.asakusafw.vanilla', name: 'asakusa-vanilla-gradle', version: System.getProperty('vanilla', versions.vanilla)
+    compile group: 'com.asakusafw.mapreduce', name: 'asakusa-mapreduce-gradle', version: System.getProperty('mapreduce', versions.mapreduce)
 
     testCompile gradleTestKit()
     testCompile group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: System.getProperty('sdk', versions.sdk), classifier: 'tests'
     testCompile 'junit:junit:4.12'
 
     deployerJars 'org.springframework.build:aws-maven:5.0.0.RELEASE'
+}
+
+eclipse.jdt {
+    javaRuntimeName = "JavaSE-${sourceCompatibility}"
+}
+if (project.hasProperty('referProject')) {
+    eclipse.classpath.file.whenMerged { classpath ->
+        classpath.entries = classpath.entries.collect { entry ->
+            if (entry instanceof org.gradle.plugins.ide.eclipse.model.Library \
+                    && entry.moduleVersion \
+                    && entry.moduleVersion.name ==~ /asakusa-(gradle-\w+|\w+-gradle)/ ) {
+                new org.gradle.plugins.ide.eclipse.model.ProjectDependency("/${entry.moduleVersion.name}")
+            } else {
+                entry
+            }
+        }.unique() as List
+    }
 }
 
 uploadArchives {

--- a/gradle/distribution.properties
+++ b/gradle/distribution.properties
@@ -19,3 +19,4 @@ sdk: 0.9.2-SNAPSHOT
 spark: 0.4.2-SNAPSHOT
 m3bp: 0.2.2-SNAPSHOT
 vanilla: 0.4.2-SNAPSHOT
+mapreduce: 0.9.2-SNAPSHOT

--- a/gradle/src/test/groovy/com/asakusafw/distribution/gradle/plugins/AsakusaUpgradeTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/distribution/gradle/plugins/AsakusaUpgradeTest.groovy
@@ -25,6 +25,7 @@ import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
 import com.asakusafw.gradle.plugins.GradleTestkitHelper
 import com.asakusafw.lang.gradle.plugins.AsakusafwLangPlugin
 import com.asakusafw.m3bp.gradle.plugins.AsakusafwM3bpPlugin
+import com.asakusafw.mapreduce.gradle.plugins.AsakusafwMapReducePlugin
 import com.asakusafw.spark.gradle.plugins.AsakusafwSparkPlugin
 import com.asakusafw.vanilla.gradle.plugins.AsakusafwVanillaPlugin
 
@@ -88,14 +89,16 @@ class AsakusaUpgradeTest {
             AsakusafwSparkPlugin,
             AsakusafwM3bpPlugin,
             AsakusafwVanillaPlugin,
+            AsakusafwMapReducePlugin,
             'META-INF/gradle-plugins/asakusafw-sdk.properties',
             'META-INF/gradle-plugins/asakusafw-lang.properties',
             'META-INF/gradle-plugins/asakusafw-spark.properties',
             'META-INF/gradle-plugins/asakusafw-m3bp.properties',
-            'META-INF/gradle-plugins/asakusafw-vanilla.properties')
+            'META-INF/gradle-plugins/asakusafw-vanilla.properties',
+            'META-INF/gradle-plugins/asakusafw-mapreduce.properties')
         String script = GradleTestkitHelper.getSimpleBuildScript(classpath,
             'asakusafw-sdk', 'asakusafw-organizer',
-            'asakusafw-spark', 'asakusafw-m3bp', 'asakusafw-vanilla')
+            'asakusafw-spark', 'asakusafw-m3bp', 'asakusafw-vanilla', 'asakusafw-mapreduce')
         GradleTestkitHelper.runGradle(projectDir.root, version, script, AsakusafwBasePlugin.TASK_UPGRADE)
     }
 }


### PR DESCRIPTION
## Summary

This PR adds `asakusa-mapreduce-gradle` artifact introduced asakusafw/asakusafw-mapreduce#2 into upstream dependencies of Asakusa distribution Gradle plug-ins.

## Background, Problem or Goal of the patch

Since asakusafw/asakusafw-mapreduce#2, Gradle plug-in `asakusafw-mapreduce` has been removed from `asakusa-gradle-plugins` project.

## Design of the fix, or a new feature

see asakusafw/asakusafw-mapreduce#2

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-mapreduce#2
