### PR TITLE
Bump Gradle required Java version to 1.8.

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     deployerJars 'org.springframework.build:aws-maven:5.0.0.RELEASE'
 }
 
+project.sourceCompatibility = JavaVersion.toVersion('1.8')
+
 eclipse.jdt {
     javaRuntimeName = "JavaSE-${sourceCompatibility}"
 }


### PR DESCRIPTION
## Summary

This PR bumps Gradle required JDK version to `1.8`.

## Background, Problem or Goal of the patch

See asakusafw/asakusafw#760.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* See asakusafw/asakusafw#760.