### PR TITLE
Fix for upstream (remove `vanilla.useSystemHadoop`).

### DIFF
--- a/integration/src/integration-test/data/distribution/build.gradle
+++ b/integration/src/integration-test/data/distribution/build.gradle
@@ -39,7 +39,6 @@ asakusafwOrganizer {
     }
     vanilla {
         enabled true
-        useSystemHadoop System.getenv('HADOOP_CMD') as boolean
     }
     m3bp {
         useSystemHadoop System.getenv('HADOOP_CMD') as boolean


### PR DESCRIPTION
## Summary

This PR fixes integration for upstream change (asakusafw/asakusafw-compiler#162).

## Background, Problem or Goal of the patch

See asakusafw/asakusafw-compiler#162.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#162