### PR TITLE
Change maven repository URL to use https in template build.gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd gradle
 # build.gradle on your project
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '<x.y.z>'

--- a/gradle/src/templates/asakusa-m3bp-template/build.gradle
+++ b/gradle/src/templates/asakusa-m3bp-template/build.gradle
@@ -2,7 +2,7 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/${mavenRepoType}' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/${mavenRepoType}' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '${gradlePluginVersion}'

--- a/gradle/src/templates/asakusa-mapreduce-template/build.gradle
+++ b/gradle/src/templates/asakusa-mapreduce-template/build.gradle
@@ -2,7 +2,7 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/${mavenRepoType}' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/${mavenRepoType}' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '${gradlePluginVersion}'

--- a/gradle/src/templates/asakusa-spark-template/build.gradle
+++ b/gradle/src/templates/asakusa-spark-template/build.gradle
@@ -2,7 +2,7 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/${mavenRepoType}' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/${mavenRepoType}' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '${gradlePluginVersion}'

--- a/gradle/src/templates/asakusa-vanilla-template/build.gradle
+++ b/gradle/src/templates/asakusa-vanilla-template/build.gradle
@@ -2,7 +2,7 @@ group 'com.example'
 
 buildscript {
     repositories {
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/${mavenRepoType}' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/${mavenRepoType}' }
     }
     dependencies {
         classpath group: 'com.asakusafw.gradle', name: 'asakusa-distribution', version: '${gradlePluginVersion}'


### PR DESCRIPTION
## Summary
This PR changes maven repository URL protocol from http to https in `build.gradle` of batch application template projects.

## Background, Problem or Goal of the patch
Follow-up asakusafw/asakusafw#845

## Design of the fix, or a new feature
The same as asakusafw/asakusafw#845

## Related Issue, Pull Request or Code
N/A.
